### PR TITLE
fix: unify Google AI API key environment variable

### DIFF
--- a/env.example
+++ b/env.example
@@ -15,6 +15,10 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Database Configuration
 DATABASE_URL="file:./dev.db"
 
+# Google AI (Gemini) API Key - Required for AI features
+# Get your API key from https://aistudio.google.com/apikey
+GOOGLE_API_KEY=your_google_ai_api_key_here
+
 # for google login: 
 # Go to https://console.cloud.google.com/ signup and create new project, complete all steps, and after generating credentials fill up credentials of your project:
 GOOGLE_CLIENT_ID=""

--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -12,7 +12,7 @@ const memory = new MemorySaver();
 const llm = new ChatGoogleGenerativeAI({
   model: "gemini-1.5-flash",
   temperature: 0.7,
-  apiKey: process.env.GEMINI_API_KEY,  // Ensure this is in .env.local
+  apiKey: process.env.GOOGLE_API_KEY,  // Ensure this is in .env.local
 });
 
 // Lazy-load the agent (avoids top-level await issues)


### PR DESCRIPTION
## Summary

Fixes #245

The codebase used inconsistent environment variable names for the Google Gemini API key, causing confusion and runtime errors.

### Problem

| File | Variable Used |
|------|--------------|
| `src/ai/agent.ts` | `GEMINI_API_KEY` |
| `src/ai/genkit.ts` (via `@genkit-ai/googleai`) | `GOOGLE_API_KEY` (default) |
| `README.md` | `GOOGLE_API_KEY` |
| `env.example` | *(missing entirely)* |

Users following the README would set `GOOGLE_API_KEY`, but the agent module would fail because it looked for `GEMINI_API_KEY`.

### Changes

1. **`src/ai/agent.ts`**: Changed `GEMINI_API_KEY` to `GOOGLE_API_KEY`
2. **`env.example`**: Added `GOOGLE_API_KEY` entry with instructions and link to Google AI Studio

### Impact

- All AI modules now consistently use `GOOGLE_API_KEY`
- `env.example` now documents all required environment variables
- No breaking change for users who already set `GOOGLE_API_KEY` per the README

---
*Generated with Auto Bounty Hunter.*