### PR TITLE
Fix: Added auto-scroll to validation errors on signup page

### DIFF
--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, Suspense } from "react";
+import { useEffect, useState, Suspense, useRef } from "react";
 import {
   User,
   Mail,
@@ -27,6 +27,16 @@ function MedGenieRegisterForm() {
   const [error, setError] = useState("");
   const [isFromLogin, setIsFromLogin] = useState(false);
   const { register, isLoading } = useAuth();
+  const errorContainerRef = useRef<HTMLDivElement>(null);
+  // 2. ADD THIS EFFECT:
+  useEffect(() => {
+    if (error) {
+      errorContainerRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [error]);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -92,8 +102,8 @@ function MedGenieRegisterForm() {
 
     if (password !== confirmPassword) {
       setError("Passwords do not match!");
-      return;
-    }
+  return;
+}
 
     const result = await register(username, email, password, confirmPassword);
 
@@ -145,10 +155,10 @@ function MedGenieRegisterForm() {
         )}
 
         {error && (
-          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl">
-            <p className="text-red-400 text-sm text-center">{error}</p>
-          </div>
-        )}
+  <div ref={errorContainerRef} className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl">
+    <p className="text-red-400 text-sm text-center">{error}</p>
+  </div>
+)}
 
         <form onSubmit={handleRegister} className="space-y-6">
           {/* Username */}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #310

## Rationale for this change

When a user submits the signup form with invalid data (like mismatched passwords), the error message appears at the top section of the form. If the user has scrolled down to click the "Register" button, they cannot see the error. This creates confusion because it looks like the button is broken or the form failed silently. Adding an automatic scroll fixes this UX issue.

## What changes are included in this PR?

- Added a React `useRef` to target the validation error message container.
- Added a `useEffect` hook to monitor the form's `error` state.
- Implemented smooth scrolling via `scrollIntoView` to automatically bring the error banner into the center of the screen when validation fails.

## Are these changes tested?

Yes, manually tested and verified locally on the development server. The signup page now smoothly scrolls directly to the error message container upon any validation failure.

## Are there any user-facing changes?

Yes, a minor UI/UX interaction improvement. Users will now experience an automatic, smooth scroll to the validation feedback area if their form submission contains errors.