### PR TITLE
Fix Try Demo button redirect issue

### DIFF
--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -294,7 +294,7 @@ export default function ServicesPage() {
                                 </Link>
                             </Button>
                             <Button variant="outline" size="lg" className="bg-transparent border-2 border-primary-foreground text-primary-foreground hover:bg-primary-foreground hover:text-primary font-semibold px-8 py-4 text-lg rounded-2xl transition-all duration-300 transform hover:-translate-y-1" asChild>
-                                <Link href="/chat">
+                                <Link href="/homepage">
                                     Try Demo
                                     <MessageSquare className="h-5 w-5 ml-2" />
                                 </Link>


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #269

## Rationale for this change

The "Try Demo" button was redirecting users to a non-existent `/chat` route, resulting in a 404 page.

## What changes are included in this PR?

* Updated the button redirect route
* Removed navigation to invalid `/chat` page
* Redirected users to an existing valid page

## Are these changes tested?

Yes, the changes were tested locally by running the project and verifying that the "Try Demo" button redirects correctly without showing a 404 page.

## Are there any user-facing changes?

Yes, users clicking the "Try Demo" button are now redirected correctly instead of encountering a 404 page.
