### PR TITLE
fix(auth) : populate user data during token refresh

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,47 +1,61 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyRefreshToken, signAccessToken, blacklistToken } from '@/lib/jwt';
-import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from "next/server";
+import { verifyRefreshToken, signAccessToken, blacklistToken } from "@/lib/jwt";
+import { cookies } from "next/headers";
+import { SecurePrisma } from "@/lib/secure-prisma";
 
 export async function POST(req: NextRequest) {
-    try {
-        const cookieStore = cookies();
-        const refreshToken = cookieStore.get('refresh_token')?.value;
+  try {
+    const cookieStore = cookies();
+    const refreshToken = cookieStore.get("refresh_token")?.value;
 
-        if (!refreshToken) {
-            return NextResponse.json(
-                { success: false, message: 'Refresh token not found' },
-                { status: 401 }
-            );
-        }
-
-        const decoded = await verifyRefreshToken(refreshToken);
-        if (!decoded) {
-            return NextResponse.json(
-                { success: false, message: 'Invalid refresh token' },
-                { status: 401 }
-            );
-        }
-
-        // Generate new access token
-        const newAccessToken = signAccessToken({
-            userId: decoded.userId,
-            email: '', // Will be filled by the sign function
-            name: '',  // Will be filled by the sign function
-            tokenId: decoded.tokenId,
-        });
-
-        // Blacklist old refresh token (optional - implement rotation)
-        // await blacklistToken(decoded.tokenId);
-
-        return NextResponse.json({
-            success: true,
-            accessToken: newAccessToken,
-        });
-
-    } catch (error) {
-        return NextResponse.json(
-            { success: false, message: 'Token refresh failed' },
-            { status: 500 }
-        );
+    if (!refreshToken) {
+      return NextResponse.json(
+        { success: false, message: "Refresh token not found" },
+        { status: 401 },
+      );
     }
+
+    const decoded = await verifyRefreshToken(refreshToken);
+    if (!decoded) {
+      return NextResponse.json(
+        { success: false, message: "Invalid refresh token" },
+        { status: 401 },
+      );
+    }
+
+    // Generate new access token
+    const ipAddress = req.headers.get("x-forwarded-for") || "unknown";
+
+    const user = await SecurePrisma.getUserProfile(decoded.userId, ipAddress);
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "User not found",
+        },
+        { status: 401 },
+      );
+    }
+
+    const newAccessToken = signAccessToken({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      tokenId: decoded.tokenId,
+    });
+
+    // Blacklist old refresh token (optional - implement rotation)
+    // await blacklistToken(decoded.tokenId);
+
+    return NextResponse.json({
+      success: true,
+      accessToken: newAccessToken,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: "Token refresh failed" },
+      { status: 500 },
+    );
+  }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #387

## Rationale for this change

The token refresh endpoint was generating new access tokens with hardcoded empty strings for the `email` and `name` fields.

Since refresh tokens only contain `userId` and `tokenId`, the endpoint had no access to the user's profile information and incorrectly assumed these fields would be populated automatically during token signing.

As a result, all refreshed access tokens contained empty values for `email` and `name`, causing issues in authenticated routes, user-facing displays, and audit logging.

## What changes are included in this PR?

- Added a database lookup using `SecurePrisma.getUserProfile()` during token refresh.
- Retrieved the user's current `email` and `name` using the `userId` from the refresh token payload.
- Added validation to ensure the user exists before generating a new access token.
- Generated refreshed access tokens with the correct user information instead of empty strings.
- Removed the dependency on hardcoded placeholder values for JWT claims.

## Are these changes tested?

Yes.

The refresh token flow was verified by:

1. Authenticating a user and obtaining access and refresh tokens.
2. Triggering the token refresh endpoint.
3. Confirming that the newly generated access token contains the correct `userId`, `email`, `name`, and `tokenId` claims.
4. Verifying that requests using the refreshed access token continue to receive valid user information.

## Are there any user-facing changes?

No UI changes were introduced.

This change fixes the backend token refresh flow and ensures that refreshed access tokens retain accurate user information.