### PR TITLE
feat: improve AI response feedback states in chat interface

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -9,13 +9,29 @@ interface Message {
 export default function ChatInterface() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [pendingAssistantIndex, setPendingAssistantIndex] = useState<number | null>(null);
+  const [failedAssistantIndex, setFailedAssistantIndex] = useState<number | null>(null);
+  const [lastUserMessageForRetry, setLastUserMessageForRetry] = useState<string | null>(null);
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim()) return;
-
     const userMessage = input;
-    setMessages(prev => [...prev, { role: 'user' as const, content: userMessage }]);
+    // mark loading state
+    setIsLoading(true);
+    setLastUserMessageForRetry(userMessage);
+    setFailedAssistantIndex(null);
+
+    // append user message and a temporary assistant loading message
+    const assistantIndexLocal = messages.length + 1; // user appended at messages.length, assistant will be +1
+    setMessages(prev => {
+      const next = [...prev, { role: 'user' as const, content: userMessage }, { role: 'assistant' as const, content: 'Generating response...' }];
+      // reflect pending assistant in state for rendering (not relied on for immediate updates)
+      setPendingAssistantIndex(assistantIndexLocal);
+      return next;
+    });
+
     setInput('');
 
     try {
@@ -32,10 +48,54 @@ export default function ChatInterface() {
 
       const data = await res.json();
 
-      setMessages(prev => [...prev, { role: 'assistant' as const, content: data.response }]);
+      // replace the temporary assistant message with real response using the local index
+      setMessages(prev => prev.map((m, i) => i === assistantIndexLocal ? { role: 'assistant', content: data.response } : m));
+      setPendingAssistantIndex(null);
+      setIsLoading(false);
     } catch (error) {
       console.error(error);
-      setMessages(prev => [...prev, { role: 'assistant' as const, content: "Error: Try again!" }]);
+      // show friendly failure message and enable retry on that assistant message
+      setMessages(prev => prev.map((m, i) => i === assistantIndexLocal ? { role: 'assistant', content: "Sorry — I couldn't generate a response. Tap Retry to try again." } : m));
+      setFailedAssistantIndex(assistantIndexLocal);
+      setPendingAssistantIndex(null);
+      setIsLoading(false);
+    }
+  };
+
+  const handleRetry = async () => {
+    if (isLoading) return; // guard
+    if (lastUserMessageForRetry == null || failedAssistantIndex == null) return;
+    // capture the failed assistant index locally to avoid relying on async state updates
+    const assistantIndexLocal = failedAssistantIndex;
+    setIsLoading(true);
+    setFailedAssistantIndex(null);
+    // set the failed assistant message back to loading text
+    setMessages(prev => prev.map((m, i) => i === assistantIndexLocal ? { role: 'assistant', content: 'Generating response...' } : m));
+    setPendingAssistantIndex(assistantIndexLocal);
+
+    try {
+      const res = await fetch("/api/chat/agent/route", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: lastUserMessageForRetry,
+          sessionId: "abhinav-capstone-2025",
+        }),
+      });
+
+      if (!res.ok) throw new Error(`Error: ${res.status}`);
+
+      const data = await res.json();
+
+      setMessages(prev => prev.map((m, i) => i === assistantIndexLocal ? { role: 'assistant', content: data.response } : m));
+      setPendingAssistantIndex(null);
+      setIsLoading(false);
+    } catch (error) {
+      console.error(error);
+      setMessages(prev => prev.map((m, i) => i === assistantIndexLocal ? { role: 'assistant', content: "Sorry — I couldn't generate a response. Tap Retry to try again." } : m));
+      setFailedAssistantIndex(assistantIndexLocal);
+      setPendingAssistantIndex(null);
+      setIsLoading(false);
     }
   };
 
@@ -44,7 +104,14 @@ export default function ChatInterface() {
       <div className="messages">
         {messages.map((msg, idx) => (
           <div key={idx} className={`message ${msg.role}`}>
-            <strong>{msg.role}:</strong> {msg.content}
+            <strong>{msg.role}:</strong>
+            <span style={{ marginLeft: 6 }}>{msg.content}</span>
+            {idx === pendingAssistantIndex && (
+              <span style={{ marginLeft: 8, fontStyle: 'italic', color: '#666' }}>Generating response...</span>
+            )}
+            {idx === failedAssistantIndex && (
+              <button onClick={handleRetry} style={{ marginLeft: 8 }} disabled={isLoading}>Retry</button>
+            )}
           </div>
         ))}
       </div>
@@ -53,9 +120,10 @@ export default function ChatInterface() {
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          disabled={isLoading}
           placeholder="Ask about symptoms, dosage, etc..."
         />
-        <button type="submit">Send</button>
+        <button type="submit" disabled={isLoading || !input.trim()}>{isLoading ? 'Generating...' : 'Send'}</button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #234

## Rationale for this change

While using the chat flow, the interface did not give much feedback while waiting for an AI response. This could make the app feel unresponsive, especially when the backend/API takes a few seconds or fails temporarily. This change improves clarity for users during AI response generation.

## What changes are included in this PR?

- Added loading feedback while the AI response is being generated
- Disabled the input and send button during request processing
- Updated the send button text to show `Generating...`
- Added a friendly error message when response generation fails
- Added a retry option for failed AI responses
- Improved loading/retry handling to avoid relying on async React state updates

## Are these changes tested?

Tested locally by mounting the chat component through a temporary local route to verify loading, disabled input/button, and retry behavior. The temporary route was removed before committing. Project-wide typecheck currently shows existing unrelated errors outside this component.

## Are there any user-facing changes?

Yes. Users now get clearer feedback while an AI response is being generated, and they can retry if the request fails instead of only seeing a static error message.
