### PR TITLE
fix: add back navigation to privacy, terms and cookie pages

### DIFF
--- a/public/privacypolicy.html
+++ b/public/privacypolicy.html
@@ -10,7 +10,29 @@
   <link rel="stylesheet" href="privacypolicy.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    
+    .back-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      white-space: nowrap;
+      height: 40px;
+      margin-bottom: 16px;
+      padding: 0 16px;
+      border-radius: var(--radius-md);
+      cursor: pointer;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.02);
+      color: var(--fg);
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 1;
+      transition: background-color .2s ease, color .2s ease, border-color .2s ease;
+    }
+    .back-button:hover {
+      background: rgba(255, 255, 255, 0.12);
+      border-color: rgba(255, 255, 255, 0.35);
+    }
   </style>
 </head>
 <body>
@@ -42,6 +64,13 @@
 
   <main class="shell">
     <article class="card" role="article">
+      <button
+      onclick="window.history.back()"
+      aria-label="Go back to previous page"
+      class="back-button"
+    >
+      ← Back
+    </button>
       <div class="head">
         <h2>Privacy Policy</h2>
         <div class="badge" id="last-updated">Last Updated: August 15, 2025</div>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,9 +1,22 @@
+"use client";
 import Layout from "@/components/layout";
 
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
 export default function CookiePolicyPage() {
+  const router = useRouter();
   return (
-    <Layout>
-    <div className="max-w-4xl mx-auto p-6">
+    <Layout><div className="max-w-4xl mx-auto p-6 pt-32">
+      <Button
+      variant="outline"
+      className="mb-4"
+      onClick={() => router.back()}
+      aria-label="Go back to previous page"
+    >
+      ← Back
+    </Button>
       <h1 className="text-3xl font-bold mb-4">Cookie Policy</h1>
       <p className="mb-2">
         This Cookie Policy explains how Med-Genie uses cookies and similar technologies to

--- a/src/app/terms-of-use/page.tsx
+++ b/src/app/terms-of-use/page.tsx
@@ -1,9 +1,21 @@
+"use client";
 import Layout from "@/components/layout";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 export default function TermsOfUsePage() {
+  const router = useRouter();
   return (
     <Layout>
-    <div className="max-w-4xl mx-auto p-6">
+    <div className="max-w-4xl mx-auto p-6 pt-32">
+       <Button
+      variant="outline"
+      className="mb-4"
+      onClick={() => router.back()}
+      aria-label="Go back to previous page"
+    >
+      ← Back
+    </Button>
       <h1 className="text-3xl font-bold mb-4">Terms of Use</h1>
       <p className="mb-2">
         Welcome to Med-Genie. By using our platform, you agree to the following terms and

--- a/src/components/landing_page/Footer.tsx
+++ b/src/components/landing_page/Footer.tsx
@@ -147,7 +147,7 @@ const Footer = () => {
               </li>
               <li>
                 <a
-                  href="/terms.html"
+                  href="/terms-of-use"
                   className="hover:text-white transition-colors"
                 >
                   Terms of Use
@@ -155,7 +155,7 @@ const Footer = () => {
               </li>
               <li>
                 <a
-                  href="/cookies.html"
+                  href="/cookie-policy"
                   className="hover:text-white transition-colors"
                 >
                   Cookie Policy

--- a/src/components/landing_page/privacypolicy.html
+++ b/src/components/landing_page/privacypolicy.html
@@ -10,11 +10,23 @@
   <link rel="stylesheet" href="privacypolicy.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    
+    .back-button {
+      margin-bottom: 16px;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      border: 1px solid #ccc;
+      background: white;
+    }
   </style>
 </head>
 <body>
+  
+  <div class="container">
+
+    
   <!-- Sticky glass navigation -->
+
   <header class="site-header" id="top">
     <nav class="nav" aria-label="Primary">
       <div class="brand">
@@ -42,6 +54,13 @@
 
   <main class="shell">
     <article class="card" role="article">
+      <button
+      onclick="window.history.back()"
+      aria-label="Go back to previous page"
+      class="back-button"
+    >
+      ← Back
+    </button>
       <div class="head">
         <h2 data-aos="fade-up">Privacy Policy</h2>
         <div data-aos="fade-up" class="badge" id="last-updated">Last Updated: August 15, 2025</div>


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #393

## Rationale for this change

The Cookie Policy, Terms of Use, and Privacy Policy pages did not provide users with an easy way to navigate back to the previous page. This change improves usability by adding a dedicated Back button on each legal page while maintaining consistency with the existing UI.

## What changes are included in this PR?

* Added a Back button to the Cookie Policy page.
* Added a Back button to the Terms of Use page.
* Added a Back button to the Privacy Policy page.
* Implemented browser-history navigation:

  * `router.back()` for Next.js pages.
  * `window.history.back()` for the static Privacy Policy page.
* Updated footer navigation links where necessary.
* Adjusted page spacing to prevent overlap with the fixed navbar.
* Added accessibility labels (`aria-label`) to the navigation buttons.

## Are these changes tested?

Yes.

Tested the following navigation flows:

* Home → Cookie Policy → Back
* Home → Terms of Use → Back
* Home → Privacy Policy → Back

Also verified responsiveness on:

* Desktop
* Tablet
* Mobile

Confirmed that the application runs successfully with no build errors using:

```bash
npm run dev
```

## Are there any user-facing changes?

Yes.

Users will now see a Back button on the Cookie Policy, Terms of Use, and Privacy Policy pages, allowing them to easily return to the previous page.
## Additional improvements

While implementing this feature, I discovered that the footer 
navigation links were pointing to non-existent file paths. 
I corrected these links to match the actual page routes:

* Updated privacy policy link from: `/cookies.html` → `/cookie-policy`
* Updated terms link from: `/terms.html` → `/terms-of-use`


This ensures users can navigate to these pages and use the 
new back buttons.
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/58cf4773-b02f-475d-a32a-c80241c4a4bc" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/741a6ad9-af97-4e10-b034-4ea8cf7fb4ba" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/398fe2a7-f597-4d9f-b8a8-60a91fe2fe6f" />
