### PR TITLE
fix: prevent blank chat submissions

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -9,12 +9,13 @@ interface Message {
 export default function ChatInterface() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
+  const trimmedInput = input.trim();
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!input.trim()) return;
+    if (!trimmedInput) return;
 
-    const userMessage = input;
+    const userMessage = trimmedInput;
     setMessages(prev => [...prev, { role: 'user' as const, content: userMessage }]);
     setInput('');
 
@@ -55,7 +56,7 @@ export default function ChatInterface() {
           onChange={(e) => setInput(e.target.value)}
           placeholder="Ask about symptoms, dosage, etc..."
         />
-        <button type="submit">Send</button>
+        <button type="submit" disabled={!trimmedInput}>Send</button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- prevent whitespace-only chat messages from being submitted
- trim the message before it is displayed and sent to the chat API
- disable the send button when the input only contains whitespace

## Root Cause
The chat form checked trimmed input before submit, but it still used the original untrimmed value for the displayed message and API payload. The submit button also remained enabled for whitespace-only values.

## Changes Made
- derive a trimmed chat input value
- use the trimmed value for the user message and API request
- disable the send button when the trimmed input is empty

## Testing
- npm ci fails with an existing peer dependency resolution conflict between @langchain/community@1.0.3, @browserbasehq/stagehand, and dotenv@17.2.3
- npm ci --legacy-peer-deps
- npx tsc --noEmit --jsx react-jsx --module esnext --moduleResolution bundler --target es2022 --esModuleInterop --skipLibCheck src/components/ChatInterface.tsx
- git diff --check
- npm run typecheck is currently blocked by existing repo-wide errors unrelated to this file, including missing test globals and stale auth/Prisma fields

## Impact
Users can no longer submit blank or whitespace-only chat messages, and messages with accidental leading/trailing spaces are normalized before reaching the chat API.

Fixes #398