### PR TITLE
fix(a11y): Add ARIA labels to chat sidebar dropdown menus

### DIFF
--- a/src/components/chat-history-sidebar.tsx
+++ b/src/components/chat-history-sidebar.tsx
@@ -128,6 +128,7 @@ export function ChatHistorySidebar({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem 
+                      aria-label="Rename conversation"
                       onClick={(e) => {
                         e.stopPropagation();
                         handleOpenRenameDialog(session.id, session.name);
@@ -137,6 +138,7 @@ export function ChatHistorySidebar({
                       Rename
                     </DropdownMenuItem>
                     <DropdownMenuItem 
+                      aria-label="Delete conversation"
                       className="text-destructive focus:text-destructive"
                       onClick={(e) => {
                         e.stopPropagation();


### PR DESCRIPTION
Resolves #<ISSUE_ID_PENDING>

### Description
This small PR adds missing \ria-label\ attributes to the DropdownMenuItems (Rename, Delete) in the \ChatHistorySidebar\ to improve screen reader accessibility.

- [x] Verified with NVDA/VoiceOver screen reader behavior