### PR TITLE
feat(ux): Add autoFocus to chat input

### DIFF
--- a/src/app/homepage/page.tsx
+++ b/src/app/homepage/page.tsx
@@ -494,6 +494,7 @@ function HomePage() {
                     onChange={(e) => handleInputChange(e.target.value)}
                     placeholder="Ask anything about your health..."
                     disabled={isLoading}
+                    autoFocus
                     className={`pr-24 ${inputError ? 'border-red-500 focus:border-red-500' : ''}`}
                   />
                   {inputError && (


### PR DESCRIPTION
Resolves #<ISSUE_ID_PENDING>

### Description
This PR adds the \utoFocus\ attribute to the main Chat \Input\ component in the Dashboard. This simple UX tweak allows users to start typing their health questions immediately when the page loads, without needing to click the input box first.

- [x] Tested locally