### PR TITLE
refactor(perf): Memoize ChatMessageItem to prevent unnecessary re-renders

### DIFF
--- a/src/components/chat-message-item.tsx
+++ b/src/components/chat-message-item.tsx
@@ -15,7 +15,9 @@ interface ChatMessageItemProps {
   onFeedback: (messageId: string, feedback: "good" | "bad") => void;
 }
 
-export function ChatMessageItem({ message, onFeedback }: ChatMessageItemProps) {
+import React from "react";
+
+export const ChatMessageItem = React.memo(function ChatMessageItem({ message, onFeedback }: ChatMessageItemProps) {
   const isUser = message.sender === "user";
   const Icon = isUser ? UserCircle2 : RobotDoctorIcon;
 
@@ -148,4 +150,6 @@ export function ChatMessageItem({ message, onFeedback }: ChatMessageItemProps) {
       )}
     </div>
   );
-}
+});
+
+ChatMessageItem.displayName = "ChatMessageItem";


### PR DESCRIPTION
Resolves #<ISSUE_ID_PENDING>

### Description
This PR wraps the \ChatMessageItem\ component in \React.memo\. In long chat sessions, appending a new message previously caused the entire message list to re-render. Memoizing the individual message item significantly improves frontend performance during active conversations.

- [x] Tested locally