### PR TITLE
fix: missing await in token blacklist check and rate-limit reset time

### DIFF
--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -81,7 +81,7 @@ export const signTokenPair = (userId: number, email: string, name: string): Toke
   };
 };
 
-export const verifyToken = (token: string): JWTPayload | null => {
+export const verifyToken = async (token: string): Promise<JWTPayload | null> => {
   try {
     const decoded = jwt.verify(token, getJWTSecret(), {
       algorithms: ['HS256'],
@@ -90,7 +90,7 @@ export const verifyToken = (token: string): JWTPayload | null => {
     }) as JWTPayload;
 
     // Check if token is blacklisted
-    if (isTokenBlacklisted(decoded.tokenId)) {
+    if (await isTokenBlacklisted(decoded.tokenId)) {
       return null;
     }
 
@@ -100,7 +100,7 @@ export const verifyToken = (token: string): JWTPayload | null => {
   }
 };
 
-export const verifyRefreshToken = (token: string): RefreshTokenPayload | null => {
+export const verifyRefreshToken = async (token: string): Promise<RefreshTokenPayload | null> => {
   try {
     const decoded = jwt.verify(token, getJWTSecret(), {
       algorithms: ['HS256'],
@@ -109,7 +109,7 @@ export const verifyRefreshToken = (token: string): RefreshTokenPayload | null =>
     }) as RefreshTokenPayload;
 
     // Check if refresh token is blacklisted
-    if (isTokenBlacklisted(decoded.tokenId)) {
+    if (await isTokenBlacklisted(decoded.tokenId)) {
       return null;
     }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -32,16 +32,16 @@ class MemoryRateLimitStore {
         }, 5 * 60 * 1000);
     }
 
-    async get(key: string): Promise<number> {
+    async get(key: string): Promise<{ count: number; resetTime: number }> {
         const entry = this.store[key];
-        if (!entry) return 0;
+        if (!entry) return { count: 0, resetTime: 0 };
 
         if (Date.now() > entry.resetTime) {
             delete this.store[key];
-            return 0;
+            return { count: 0, resetTime: 0 };
         }
 
-        return entry.count;
+        return { count: entry.count, resetTime: entry.resetTime };
     }
 
     async increment(key: string, windowMs: number): Promise<number> {
@@ -119,12 +119,12 @@ export function withRateLimit(config: RateLimitConfig) {
                 const ip = getClientIP(req);
                 const key = generateKey(ip, req.nextUrl.pathname, config);
 
-                // Get current count
-                const currentCount = await memoryStore.get(key);
+                // Get current count and reset time
+                const { count: currentCount, resetTime: storeResetTime } = await memoryStore.get(key);
 
                 // Check if rate limit exceeded
                 if (currentCount >= config.maxRequests) {
-                    const resetTime = Date.now() + config.windowMs;
+                    const resetTime = storeResetTime || Date.now() + config.windowMs;
                     const info = getRateLimitInfo(currentCount, config.maxRequests, resetTime);
 
                     return NextResponse.json(
@@ -147,15 +147,16 @@ export function withRateLimit(config: RateLimitConfig) {
                     );
                 }
 
-                // Increment counter
+                // Increment counter and get updated reset time
                 const newCount = await memoryStore.increment(key, config.windowMs);
+                const { resetTime: updatedResetTime } = await memoryStore.get(key);
 
                 // Execute the actual handler
                 const response = await handler(req);
 
                 // Add rate limit headers to successful responses
                 if (response.status < 400 || !config.skipSuccessfulRequests) {
-                    const resetTime = Date.now() + config.windowMs;
+                    const resetTime = updatedResetTime || Date.now() + config.windowMs;
                     const info = getRateLimitInfo(newCount, config.maxRequests, resetTime);
 
                     response.headers.set('X-RateLimit-Limit', config.maxRequests.toString());


### PR DESCRIPTION
## Bugs fixed

1. **jwt.ts**: `verifyToken` called `isTokenBlacklisted(decoded.tokenId)` without `await`. Since `isTokenBlacklisted` is async and returns `Promise<boolean>`, the Promise object is always truthy -- making every token appear blacklisted. Added `await` and made both functions properly async.

2. **rate-limit.ts**: When rate limit was exceeded, the `Retry-After` header was calculated as a full window from now instead of using the actual remaining time from the store. Changed `get()` to return both count and resetTime for accurate feedback.