### PR TITLE
fix: check response.ok before calling .json() in login and register

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -122,6 +122,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
       });
+      if (!response.ok) {
+        return { success: false, message: "Login failed" };
+      }
       const data = await response.json();
 
       if (data.success && data.accessToken && data.user) {
@@ -154,6 +157,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name, email, password, confirmPassword }),
       });
+      if (!response.ok) {
+        return { success: false, message: "Registration failed" };
+      }
       const data = await response.json();
 
       if (data.success && data.accessToken && data.user) {


### PR DESCRIPTION
login() and register() called response.json() without checking response.ok first. If the server returns a non-2xx response with a non-JSON body, the .json() call would throw an unhandled error. Added response.ok check before parsing JSON.