### PR TITLE
fix: make verifyToken/verifyRefreshToken async to properly await isTokenBlacklisted

### DIFF
--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -81,7 +81,7 @@ export const signTokenPair = (userId: number, email: string, name: string): Toke
   };
 };
 
-export const verifyToken = (token: string): JWTPayload | null => {
+export const verifyToken = async (token: string): Promise<JWTPayload | null> => {
   try {
     const decoded = jwt.verify(token, getJWTSecret(), {
       algorithms: ['HS256'],
@@ -89,8 +89,7 @@ export const verifyToken = (token: string): JWTPayload | null => {
       audience: 'med-genie-users',
     }) as JWTPayload;
 
-    // Check if token is blacklisted
-    if (isTokenBlacklisted(decoded.tokenId)) {
+    if (await isTokenBlacklisted(decoded.tokenId)) {
       return null;
     }
 
@@ -100,7 +99,7 @@ export const verifyToken = (token: string): JWTPayload | null => {
   }
 };
 
-export const verifyRefreshToken = (token: string): RefreshTokenPayload | null => {
+export const verifyRefreshToken = async (token: string): Promise<RefreshTokenPayload | null> => {
   try {
     const decoded = jwt.verify(token, getJWTSecret(), {
       algorithms: ['HS256'],
@@ -108,8 +107,7 @@ export const verifyRefreshToken = (token: string): RefreshTokenPayload | null =>
       audience: 'med-genie-refresh',
     }) as RefreshTokenPayload;
 
-    // Check if refresh token is blacklisted
-    if (isTokenBlacklisted(decoded.tokenId)) {
+    if (await isTokenBlacklisted(decoded.tokenId)) {
       return null;
     }
 


### PR DESCRIPTION
verifyToken and verifyRefreshToken were synchronous but called the async isTokenBlacklisted function without await. Since isTokenBlacklisted returns a Promise and a Promise object is always truthy, every token was incorrectly treated as blacklisted, causing all token verification to fail.

Fixed by making both functions async and properly awaiting the blacklist check.