### PR TITLE
docs: remove leftover AI-generated artifact text from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,15 +650,6 @@ You’re free to use, modify, and distribute this software with proper attributi
 
 © 2025 Med Genie — Built with ❤️ by Aayush Raj and contributors.
 
-yaml
-Copy
-Edit
----
-
-✅ You can directly **replace your current `README.md`** with this content. It’s organized, informative, and optimized for contributors, users, and open-source discoverability.
-
-Let me know if you'd like a **`CONTRIBUTING.md`**, **GitHub issue templates**, or a **feature roadmap.md** as well!
-
 
 
 


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #None (just a documentation quick fix ).

## Rationale for this change
Leftover AI-chat artifact text ("yaml / Copy / Edit" and a message asking if the user wanted more docs generated) was accidentally left at the end of README.md, which looked unprofessional and confusing to readers.

## What changes are included in this PR?
Removed the leftover AI-generated artifact text after the closing attribution line in README.md.

## Are these changes tested?
Not applicable — documentation-only change, verified visually by viewing the rendered README.

## Are there any user-facing changes?
No functional changes; only removes stray text from the README file.